### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 NAModalSheet presents your view controller with a blurred image of the background behind it - tested on iOS 6 and 7, but should be deployable on iOS 5.
 
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/v/NAModalSheet/badge.png)](http://beta.cocoapods.org/?q=name%3Anamodalsheet%2A)
-[![Cocoapods](https://cocoapod-badges.herokuapp.com/p/NAModalSheet/badge.png)](http://beta.cocoapods.org/?q=name%3Anamodalsheet%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/v/NAModalSheet/badge.png)](http://beta.cocoapods.org/?q=name%3Anamodalsheet%2A)
+[![CocoaPods](https://cocoapod-badges.herokuapp.com/p/NAModalSheet/badge.png)](http://beta.cocoapods.org/?q=name%3Anamodalsheet%2A)
 
 ## Install with CocoaPods
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
